### PR TITLE
Allow to use internal boost version provided by jinja2cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.3)
 
 project(faustpp)
 
+option(FAUSTPP_USE_INTERNAL_BOOST "Use internal Boost libraries" OFF)
 option(FAUSTPP_LINK_STATIC_BOOST "Link static Boost libraries" OFF)
 option(FAUSTPP_BUILD_EXAMPLES "Build examples" OFF)
 
@@ -37,7 +38,34 @@ target_include_directories(pugixml
 
 # boost
 set(Boost_USE_STATIC_LIBS "${FAUSTPP_LINK_STATIC_BOOST}")
+
+if(${FAUSTPP_USE_INTERNAL_BOOST})
+set(BOOST_ENABLE_CMAKE ON)
+set(BOOST_DIR ${PROJECT_SOURCE_DIR}/thirdparty/jinja2cpp/thirdparty/boost)
+set(BOOST_INCLUDE_LIBRARIES
+    algorithm
+    assert
+    atomic
+    filesystem
+    lexical_cast
+    optional
+    variant
+CACHE INTERNAL "")
+add_subdirectory(${BOOST_DIR})
+set(Boost_INCLUDE_DIRS
+  ${BOOST_DIR}/libs/algorithm/include
+  ${BOOST_DIR}/libs/container/include
+  ${BOOST_DIR}/libs/intrusive/include
+  ${BOOST_DIR}/libs/numeric/conversion/include
+  ${BOOST_DIR}/libs/range/include
+  ${BOOST_DIR}/libs/unordered/include
+  ${BOOST_DIR}/libs/variant/include
+)
+set(Boost_SYSTEM_LIBRARY Boost::system)
+set(Boost_FILESYSTEM_LIBRARY Boost::filesystem)
+else()
 find_package(Boost REQUIRED COMPONENTS "filesystem" "system")
+endif()
 
 add_library(boost INTERFACE)
 target_include_directories(boost


### PR DESCRIPTION
This allows to build faustpp without needing to install boost, which is quite handy for cross-compilation or simply reducing the number of 3rd party libs for building.

I am actually a bit confused by it tbh, because it seems the way cmake is setup at the moment that jinja2cpp will always use its internal boost version, so there could be symbol conflicts at link time?
Because you include jinja code directly for the build objects, always using its contained boost version should be something to consider.
